### PR TITLE
replace implicit conversion with implicit class

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
-version=2.0.0
-align = more
+version = "3.0.0-RC6"
+runner.dialect = scala3
+align.preset = more
 maxColumn = 100

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ such an input `typo-detector` might be used instead.
 <dependency>
   <groupId>io.github.antivanov</groupId>
   <artifactId>typo-detector_3</artifactId>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
 </dependency>
 ```
 
@@ -27,13 +27,13 @@ such an input `typo-detector` might be used instead.
 For Scala 3:
 
 ```scala
-libraryDependencies += "io.github.antivanov" %% "typo-detector" % "0.3.0"
+libraryDependencies += "io.github.antivanov" %% "typo-detector" % "0.4.0"
 ```
 
 For Scala 2:
 
 ```scala
-libraryDependencies += ("io.github.antivanov" %% "typo-detector" % "0.3.0")
+libraryDependencies += ("io.github.antivanov" %% "typo-detector" % "0.4.0")
   .cross(CrossVersion.for2_13Use3)
 ```
 
@@ -52,7 +52,7 @@ ThisBuild / scalacOptions := Seq(
 Enhancing the `String` class with `containsExactOrTypoOf` method
 
 ```scala
-import io.github.antivanov.typo.detector.TypoDetector.TypoAwareString._
+import io.github.antivanov.typo.detector.syntax._
 
 "Quick bron fox jumps over the lazy dog".containsExactOrTypoOf("brown fox")
 ```
@@ -70,7 +70,7 @@ TypoDetector.containsExactOrTypoOf("Quick bron fox jumps over the lazy dog", "br
 Enhancing the `String` class with `isTypoOf` method
 
 ```scala
-import io.github.antivanov.typo.detector.TypoDetector.TypoAwareString._
+import io.github.antivanov.typo.detector.syntax._
 
 val acknowlegmentText = "acknowlege"
 val isAcknowledged = acknowlegmentText.isTypoOf("acknowledge")
@@ -99,7 +99,7 @@ to detect typos, for example:
 Enhancing the `String` class with `isTypoOf` method
 
 ```scala
-import io.github.antivanov.typo.detector.TypoDetector.TypoAwareString._
+import io.github.antivanov.typo.detector.syntax._
 
 val misspelledWord = "gementeradverkiezingen"
 val isMisspelled = misspelledWord.isTypoOf("gemeenteraadsverkiezingen", maxMistypedSymbols = 5)
@@ -121,7 +121,7 @@ val isMisspelled = TypoDetector.isTypoOf(misspelledWord, "gemeenteraadsverkiezin
 Enhancing the `String` class with `editDistanceFrom` method
 
 ```scala
-import io.github.antivanov.typo.detector.TypoDetector.TypoAwareString._
+import io.github.antivanov.typo.detector.syntax._
 
 val acknowlegmentText = "acknowlege"
 val distance = acknowlegmentText.editDistanceFrom("acknowledge")

--- a/build.sbt
+++ b/build.sbt
@@ -9,10 +9,12 @@ lazy val root = (project in file("."))
   )
 
 ThisBuild / scalaVersion     := "3.0.0"
-ThisBuild / version          := "0.3.0"
+ThisBuild / version          := "0.4.0"
 ThisBuild / name             := "typo-detector"
 ThisBuild / organization     := "io.github.antivanov"
 ThisBuild / licenses         := Seq("MIT  " -> url("https://opensource.org/licenses/MIT"))
+
+ThisBuild / scalacOptions ++= Seq("-source", "future")
 
 ThisBuild / scmInfo := Some(
   ScmInfo(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.4")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")

--- a/src/main/scala/io/github/antivanov/typo/detector/LevenshteinDistance.scala
+++ b/src/main/scala/io/github/antivanov/typo/detector/LevenshteinDistance.scala
@@ -24,8 +24,7 @@ private[detector] object LevenshteinDistance:
       columnIndex <- (1 to secondLength)
     yield
       val substitutionCount =
-        if first(rowIndex - 1) == second(columnIndex - 1)
-        then 0
+        if first(rowIndex - 1) == second(columnIndex - 1) then 0
         else 1
 
       val deletionCost     = distances(rowIndex - 1)(columnIndex) + 1

--- a/src/main/scala/io/github/antivanov/typo/detector/TypoDetector.scala
+++ b/src/main/scala/io/github/antivanov/typo/detector/TypoDetector.scala
@@ -2,11 +2,12 @@ package io.github.antivanov.typo.detector
 
 import LevenshteinDistance.computeDistance
 
-/** Includes useful methods to search in text and test whether a string is a typo of another string */
+/** Includes useful methods to search in text and test whether a string is a typo of another string
+  */
 object TypoDetector:
 
   /** Default maximum number of mistyped symbols allowed for a string to be considered a typo
-    *  (number of symbol replacements, omitted or extra symbols)
+    * (number of symbol replacements, omitted or extra symbols)
     */
   val DefaultMaxMistypedSymbols = 2
 
@@ -18,12 +19,16 @@ object TypoDetector:
 
   /** Determines if str is a mistyped version of otherStr
     *
-    * @param str String to test for being a typo
-    * @param otherStr original String typed correctly
-    * @param maxMistypedSymbols maximum number of mistyped symbols allowed for a string to be considered a typo
-    *                             (number of symbol replacements, omitted or extra symbols)
-    * @return true if str is a typo of otherStr, false if the strings are too different for str to be considered
-    *         a typo, or str is the same as otherStr
+    * @param str
+    *   String to test for being a typo
+    * @param otherStr
+    *   original String typed correctly
+    * @param maxMistypedSymbols
+    *   maximum number of mistyped symbols allowed for a string to be considered a typo (number of
+    *   symbol replacements, omitted or extra symbols)
+    * @return
+    *   true if str is a typo of otherStr, false if the strings are too different for str to be
+    *   considered a typo, or str is the same as otherStr
     */
   def isTypoOf(
       str: String,
@@ -35,12 +40,16 @@ object TypoDetector:
 
   /** Determines if str is equal to otherStr or is its typo
     *
-    * @param str String to test for equality or being a typo
-    * @param otherStr original String typed correctly
-    * @param maxMistypedSymbols maximum number of mistyped symbols allowed for a string to be considered a typo
-    *                             (number of symbol replacements, omitted or extra symbols)
-    * @return true if str is a typo of otherStr or is equal to otherStr, false if the strings are too different for str
-    *         to be considered a typo
+    * @param str
+    *   String to test for equality or being a typo
+    * @param otherStr
+    *   original String typed correctly
+    * @param maxMistypedSymbols
+    *   maximum number of mistyped symbols allowed for a string to be considered a typo (number of
+    *   symbol replacements, omitted or extra symbols)
+    * @return
+    *   true if str is a typo of otherStr or is equal to otherStr, false if the strings are too
+    *   different for str to be considered a typo
     */
   def equalsOrTypoOf(
       str: String,
@@ -49,19 +58,23 @@ object TypoDetector:
   ): Boolean =
     str.equals(otherStr) || isTypoOf(str, otherStr, maxMistypedSymbols)
 
-  /** Tries to find wordsToFind inside text. wordsToFind are being searched as exact words occurring in the text or as
-    *  their typos with maximum mistyped maxMistypedSymbolsPerWord symbols.
+  /** Tries to find wordsToFind inside text. wordsToFind are being searched as exact words occurring
+    * in the text or as their typos with maximum mistyped maxMistypedSymbolsPerWord symbols.
     *
-    *  For example:
-    *  {{{
-    *  containsExactOrTypoOf("Quick bron fox jumps over the lazy dog", "brown fox")
-    *  }}}
-    *  evaluates to {@code true}
+    * For example:
+    * {{{
+    * containsExactOrTypoOf("Quick bron fox jumps over the lazy dog", "brown fox")
+    * }}}
+    * evaluates to {@code true}
     *
-    * @param text text to try to find the words in, might include typos
-    * @param wordsToFind words to try to find in the text
-    * @param maxMistypedSymbolsPerWord maximum number of mistyped symbols allowed per word when searching
-    * @return {@code true} if the words (maybe including typos) can be found in the text
+    * @param text
+    *   text to try to find the words in, might include typos
+    * @param wordsToFind
+    *   words to try to find in the text
+    * @param maxMistypedSymbolsPerWord
+    *   maximum number of mistyped symbols allowed per word when searching
+    * @return
+    *   {@code true} if the words (maybe including typos) can be found in the text
     */
   def containsExactOrTypoOf(
       text: String,
@@ -75,19 +88,22 @@ object TypoDetector:
 
     val positionOfStrToFind = possiblePositions.find { (position: Int) =>
       val textWordsAtPosition = textWords.slice(position, position + strToFindWords.length)
-      textWordsAtPosition.zip(strToFindWords).forall {
-        case (textWord, strToFindWord) =>
-          equalsOrTypoOf(textWord, strToFindWord, maxMistypedSymbolsPerWord)
+      textWordsAtPosition.zip(strToFindWords).forall { case (textWord, strToFindWord) =>
+        equalsOrTypoOf(textWord, strToFindWord, maxMistypedSymbolsPerWord)
       }
     }
     positionOfStrToFind.isDefined
 
-  /** Computes the "edit distance" from str to otherStr: number of symbol substitutions, insertions or deletions to
-    * transform str into otherStr. Also known as "Levenshtein distance" {@link https://en.wikipedia.org/wiki/Levenshtein_distance}
+  /** Computes the "edit distance" from str to otherStr: number of symbol substitutions, insertions
+    * or deletions to transform str into otherStr. Also known as "Levenshtein distance" {@link
+    * https://en.wikipedia.org/wiki/Levenshtein_distance}
     *
-    * @param str String to test for equality or being a typo
-    * @param otherStr original String typed correctly
-    * @return distance between str and otherStr as defined above
+    * @param str
+    *   String to test for equality or being a typo
+    * @param otherStr
+    *   original String typed correctly
+    * @return
+    *   distance between str and otherStr as defined above
     */
   def editDistanceFrom(str: String, otherStr: String): Int =
     computeDistance(str, otherStr)

--- a/src/main/scala/io/github/antivanov/typo/detector/TypoDetector.scala
+++ b/src/main/scala/io/github/antivanov/typo/detector/TypoDetector.scala
@@ -16,70 +16,6 @@ object TypoDetector:
   private def getWords(str: String): Array[String] =
     stripPunctuation(str).split("\\s+")
 
-  /** Wrapper for a String to fit it with the utility methods for working with strings with typos.
-    *
-    * @param str original string to be wrapped
-    */
-  class TypoAwareString(str: String):
-
-    /** Determines if str is a mistyped version of otherStr
-      *
-      * @param otherStr original String typed correctly
-      * @param maxMistypedSymbols maximum number of mistyped symbols allowed for a string to be considered a typo
-      *                             (number of symbol replacements, omitted or extra symbols)
-      * @return true if str is a typo of otherStr, false if the strings are too different for str to be considered
-      *         a typo, or str is the same as otherStr
-      */
-    def isTypoOf(otherStr: String, maxMistypedSymbols: Int = DefaultMaxMistypedSymbols): Boolean =
-      TypoDetector.isTypoOf(str, otherStr, maxMistypedSymbols)
-
-    /** Determines if str is equal to otherStr or is its typo
-      *
-      * @param otherStr original String typed correctly
-      * @param maxMistypedSymbols maximum number of mistyped symbols allowed for a string to be considered a typo
-      *                             (number of symbol replacements, omitted or extra symbols)
-      * @return true if str is a typo of otherStr or is equal to otherStr, false if the strings are too different for str
-      *         to be considered a typo
-      */
-    def equalsOrTypoOf(
-        otherStr: String,
-        maxMistypedSymbols: Int = DefaultMaxMistypedSymbols
-    ): Boolean =
-      TypoDetector.equalsOrTypoOf(str, otherStr, maxMistypedSymbols)
-
-    /** Tries to find wordsToFind inside text. wordsToFind are being searched as exact words occurring in the text or as
-      *  their typos with maximum mistyped maxMistypedSymbolsPerWord symbols.
-      *
-      *  For example:
-      *  {{{
-      *  "Quick bron fox jumps over the lazy dog".containsExactOrTypoOf("brown fox")
-      *  }}}
-      *  evaluates to {@code true}
-      *
-      * @param wordsToFind words to try to find in the text
-      * @param maxMistypedSymbolsPerWord maximum number of mistyped symbols allowed per word when searching
-      * @return {@code true} if the words (maybe including typos) can be found in the text
-      */
-    def containsExactOrTypoOf(
-        wordsToFind: String,
-        maxMistypedSymbolsPerWord: Int = DefaultMaxMistypedSymbols
-    ): Boolean =
-      TypoDetector.containsExactOrTypoOf(str, wordsToFind, maxMistypedSymbolsPerWord)
-
-    /** Computes the "edit distance" from str to otherStr: number of symbol substitutions, insertions or deletions to
-      * transform str into otherStr. Also known as "Levenshtein distance" {@link https://en.wikipedia.org/wiki/Levenshtein_distance}
-      *
-      * @param otherStr original String typed correctly
-      * @return distance between str and otherStr as defined above
-      */
-    def editDistanceFrom(otherStr: String): Int =
-      TypoDetector.editDistanceFrom(str, otherStr)
-
-  object TypoAwareString:
-
-    implicit def stringToString(s: String): TypoAwareString =
-      new TypoAwareString(s)
-
   /** Determines if str is a mistyped version of otherStr
     *
     * @param str String to test for being a typo
@@ -141,7 +77,7 @@ object TypoDetector:
       val textWordsAtPosition = textWords.slice(position, position + strToFindWords.length)
       textWordsAtPosition.zip(strToFindWords).forall {
         case (textWord, strToFindWord) =>
-          new TypoAwareString(textWord).equalsOrTypoOf(strToFindWord, maxMistypedSymbolsPerWord)
+          equalsOrTypoOf(textWord, strToFindWord, maxMistypedSymbolsPerWord)
       }
     }
     positionOfStrToFind.isDefined

--- a/src/main/scala/io/github/antivanov/typo/detector/syntax.scala
+++ b/src/main/scala/io/github/antivanov/typo/detector/syntax.scala
@@ -2,7 +2,8 @@ package io.github.antivanov.typo.detector
 
 import TypoDetector.*
 
-/** Extension methods for a String to fit it with the utility methods for working with strings with typos.
+/** Extension methods for a String to fit it with the utility methods for working with strings with
+  * typos.
   */
 object syntax:
 
@@ -10,22 +11,28 @@ object syntax:
 
     /** Determines if str is a mistyped version of otherStr
       *
-      * @param otherStr original String typed correctly
-      * @param maxMistypedSymbols maximum number of mistyped symbols allowed for a string to be considered a typo
-      *                             (number of symbol replacements, omitted or extra symbols)
-      * @return true if str is a typo of otherStr, false if the strings are too different for str to be considered
-      *         a typo, or str is the same as otherStr
+      * @param otherStr
+      *   original String typed correctly
+      * @param maxMistypedSymbols
+      *   maximum number of mistyped symbols allowed for a string to be considered a typo (number of
+      *   symbol replacements, omitted or extra symbols)
+      * @return
+      *   true if str is a typo of otherStr, false if the strings are too different for str to be
+      *   considered a typo, or str is the same as otherStr
       */
     def isTypoOf(otherStr: String, maxMistypedSymbols: Int = DefaultMaxMistypedSymbols): Boolean =
       TypoDetector.isTypoOf(str, otherStr, maxMistypedSymbols)
 
     /** Determines if str is equal to otherStr or is its typo
       *
-      * @param otherStr original String typed correctly
-      * @param maxMistypedSymbols maximum number of mistyped symbols allowed for a string to be considered a typo
-      *                             (number of symbol replacements, omitted or extra symbols)
-      * @return true if str is a typo of otherStr or is equal to otherStr, false if the strings are too different for str
-      *         to be considered a typo
+      * @param otherStr
+      *   original String typed correctly
+      * @param maxMistypedSymbols
+      *   maximum number of mistyped symbols allowed for a string to be considered a typo (number of
+      *   symbol replacements, omitted or extra symbols)
+      * @return
+      *   true if str is a typo of otherStr or is equal to otherStr, false if the strings are too
+      *   different for str to be considered a typo
       */
     def equalsOrTypoOf(
         otherStr: String,
@@ -33,18 +40,22 @@ object syntax:
     ): Boolean =
       TypoDetector.equalsOrTypoOf(str, otherStr, maxMistypedSymbols)
 
-    /** Tries to find wordsToFind inside text. wordsToFind are being searched as exact words occurring in the text or as
-      *  their typos with maximum mistyped maxMistypedSymbolsPerWord symbols.
+    /** Tries to find wordsToFind inside text. wordsToFind are being searched as exact words
+      * occurring in the text or as their typos with maximum mistyped maxMistypedSymbolsPerWord
+      * symbols.
       *
-      *  For example:
-      *  {{{
-      *  "Quick bron fox jumps over the lazy dog".containsExactOrTypoOf("brown fox")
-      *  }}}
-      *  evaluates to {@code true}
+      * For example:
+      * {{{
+      * "Quick bron fox jumps over the lazy dog".containsExactOrTypoOf("brown fox")
+      * }}}
+      * evaluates to {@code true}
       *
-      * @param wordsToFind words to try to find in the text
-      * @param maxMistypedSymbolsPerWord maximum number of mistyped symbols allowed per word when searching
-      * @return {@code true} if the words (maybe including typos) can be found in the text
+      * @param wordsToFind
+      *   words to try to find in the text
+      * @param maxMistypedSymbolsPerWord
+      *   maximum number of mistyped symbols allowed per word when searching
+      * @return
+      *   {@code true} if the words (maybe including typos) can be found in the text
       */
     def containsExactOrTypoOf(
         wordsToFind: String,
@@ -52,11 +63,14 @@ object syntax:
     ): Boolean =
       TypoDetector.containsExactOrTypoOf(str, wordsToFind, maxMistypedSymbolsPerWord)
 
-    /** Computes the "edit distance" from str to otherStr: number of symbol substitutions, insertions or deletions to
-      * transform str into otherStr. Also known as "Levenshtein distance" {@link https://en.wikipedia.org/wiki/Levenshtein_distance}
+    /** Computes the "edit distance" from str to otherStr: number of symbol substitutions,
+      * insertions or deletions to transform str into otherStr. Also known as "Levenshtein distance"
+      * {@link https://en.wikipedia.org/wiki/Levenshtein_distance}
       *
-      * @param otherStr original String typed correctly
-      * @return distance between str and otherStr as defined above
+      * @param otherStr
+      *   original String typed correctly
+      * @return
+      *   distance between str and otherStr as defined above
       */
     def editDistanceFrom(otherStr: String): Int =
       TypoDetector.editDistanceFrom(str, otherStr)

--- a/src/main/scala/io/github/antivanov/typo/detector/syntax.scala
+++ b/src/main/scala/io/github/antivanov/typo/detector/syntax.scala
@@ -6,7 +6,7 @@ import TypoDetector.*
   */
 object syntax:
 
-  extension (str: String)
+  implicit class TypoAwareStringSyntax(val str: String) extends AnyVal:
 
     /** Determines if str is a mistyped version of otherStr
       *

--- a/src/main/scala/io/github/antivanov/typo/detector/syntax.scala
+++ b/src/main/scala/io/github/antivanov/typo/detector/syntax.scala
@@ -1,0 +1,62 @@
+package io.github.antivanov.typo.detector
+
+import TypoDetector.*
+
+/** Extension methods for a String to fit it with the utility methods for working with strings with typos.
+  */
+object syntax:
+
+  extension (str: String)
+
+    /** Determines if str is a mistyped version of otherStr
+      *
+      * @param otherStr original String typed correctly
+      * @param maxMistypedSymbols maximum number of mistyped symbols allowed for a string to be considered a typo
+      *                             (number of symbol replacements, omitted or extra symbols)
+      * @return true if str is a typo of otherStr, false if the strings are too different for str to be considered
+      *         a typo, or str is the same as otherStr
+      */
+    def isTypoOf(otherStr: String, maxMistypedSymbols: Int = DefaultMaxMistypedSymbols): Boolean =
+      TypoDetector.isTypoOf(str, otherStr, maxMistypedSymbols)
+
+    /** Determines if str is equal to otherStr or is its typo
+      *
+      * @param otherStr original String typed correctly
+      * @param maxMistypedSymbols maximum number of mistyped symbols allowed for a string to be considered a typo
+      *                             (number of symbol replacements, omitted or extra symbols)
+      * @return true if str is a typo of otherStr or is equal to otherStr, false if the strings are too different for str
+      *         to be considered a typo
+      */
+    def equalsOrTypoOf(
+        otherStr: String,
+        maxMistypedSymbols: Int = DefaultMaxMistypedSymbols
+    ): Boolean =
+      TypoDetector.equalsOrTypoOf(str, otherStr, maxMistypedSymbols)
+
+    /** Tries to find wordsToFind inside text. wordsToFind are being searched as exact words occurring in the text or as
+      *  their typos with maximum mistyped maxMistypedSymbolsPerWord symbols.
+      *
+      *  For example:
+      *  {{{
+      *  "Quick bron fox jumps over the lazy dog".containsExactOrTypoOf("brown fox")
+      *  }}}
+      *  evaluates to {@code true}
+      *
+      * @param wordsToFind words to try to find in the text
+      * @param maxMistypedSymbolsPerWord maximum number of mistyped symbols allowed per word when searching
+      * @return {@code true} if the words (maybe including typos) can be found in the text
+      */
+    def containsExactOrTypoOf(
+        wordsToFind: String,
+        maxMistypedSymbolsPerWord: Int = DefaultMaxMistypedSymbols
+    ): Boolean =
+      TypoDetector.containsExactOrTypoOf(str, wordsToFind, maxMistypedSymbolsPerWord)
+
+    /** Computes the "edit distance" from str to otherStr: number of symbol substitutions, insertions or deletions to
+      * transform str into otherStr. Also known as "Levenshtein distance" {@link https://en.wikipedia.org/wiki/Levenshtein_distance}
+      *
+      * @param otherStr original String typed correctly
+      * @return distance between str and otherStr as defined above
+      */
+    def editDistanceFrom(otherStr: String): Int =
+      TypoDetector.editDistanceFrom(str, otherStr)

--- a/src/test/scala/io/github/antivanov/typo/detector/LevenshteinDistanceSpec.scala
+++ b/src/test/scala/io/github/antivanov/typo/detector/LevenshteinDistanceSpec.scala
@@ -2,7 +2,7 @@ package io.github.antivanov.typo.detector
 
 import org.scalatest.freespec.AnyFreeSpecLike
 import org.scalatest.matchers.should
-import LevenshteinDistance._
+import LevenshteinDistance.*
 
 class LevenshteinDistanceSpec extends AnyFreeSpecLike with should.Matchers:
   "Levenshtein distance" - {

--- a/src/test/scala/io/github/antivanov/typo/detector/TypoDetectorSpec.scala
+++ b/src/test/scala/io/github/antivanov/typo/detector/TypoDetectorSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should
 
 class TypoDetectorSpec extends AnyFreeSpecLike with should.Matchers:
 
-  import TypoDetector.TypoAwareString._
+  import syntax.*
 
   "isTypoOf" - {
 


### PR DESCRIPTION
- Enable Scala 3 future mode to support 3.1 syntax (`*` imports)
- Remove `TypoAwareString` wrapper and replace it with Cats-like `syntax._` pattern
- Upgrade `scalafmt` and reformat code

References #3